### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mark-goodall/pyqoiv/security/code-scanning/1](https://github.com/mark-goodall/pyqoiv/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build-release` job. Since this job only involves building and storing artifacts, it likely only requires `contents: read` permissions. This change will ensure that the job has the minimum necessary permissions and does not inherit potentially excessive permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
